### PR TITLE
make bot respond in channel

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 		log.Fatal(err)
 		return
 	}
-	slack.Start(echoClient)
+	slack.Start(echoClient, os.Getenv("SLACK_BOT_TOKEN"), os.Getenv("SLACK_CHANNEL_ID"))
 }
 
 func completeAuth(w http.ResponseWriter, r *http.Request) {

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -13,27 +13,31 @@ import (
 )
 
 type SlackHandler struct {
-	Spotify   spotify.Spotify
-	skipVoted bool
-	skipVotes int
-	keepVotes int
-	skipTimer *time.Timer
+	Spotify     spotify.Spotify
+	SlackWriter MessageWriter
+	skipVoted   bool
+	skipVotes   int
+	keepVotes   int
+	skipTimer   *time.Timer
 }
 
-func Start(client spotify.Spotify) {
+func Start(client spotify.Spotify, token, channelID string) {
 
 	router := mux.NewRouter()
-	router.Handle("/", NewSlackHandler(client))
+	router.Handle("/", NewSlackHandler(client, token, channelID))
 
 	fmt.Println("[INFO] Server listening")
 	http.Handle("/", router)
 	http.ListenAndServe(":8080", nil)
 }
 
-func NewSlackHandler(spotify spotify.Spotify) http.Handler {
-	return &SlackHandler{
-		Spotify: spotify,
+func NewSlackHandler(spotify spotify.Spotify, token, channelID string) http.Handler {
+	handler := &SlackHandler{
+		Spotify:     spotify,
+		SlackWriter: NewPoster(token, channelID),
 	}
+	go handler.SlackWriter.StartPoster()
+	return handler
 }
 
 func (handler *SlackHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
@@ -47,7 +51,6 @@ func (handler *SlackHandler) ServeHTTP(resp http.ResponseWriter, req *http.Reque
 		resp.WriteHeader(http.StatusUnauthorized)
 		return
 	}
-
 	switch s.Command {
 	case "/spotify":
 		response, err := handler.processSpotify(s.Text, s.ChannelID)
@@ -84,7 +87,12 @@ func (handler *SlackHandler) processSpotify(text string, channelID string) (stri
 		return fmt.Sprintf("Added %s to playlist", firstTrackFound.Prompt), nil
 	case "playing":
 		playingTrack := handler.Spotify.WhatsPlaying()
-		return fmt.Sprintf(":cd::musical_note: Now playing %s", playingTrack.Prompt), nil
+		if playingTrack.ID == "" {
+			handler.SlackWriter.Write(":upside_down_face: nothing is currently playing in the office")
+		} else {
+			handler.SlackWriter.Write(fmt.Sprintf(":cd::musical_note: Now playing %s", playingTrack.Prompt))
+		}
+		return "", nil
 	case "skip":
 		if !handler.skipVoted {
 			skipTimer := time.NewTimer(time.Second * 10)

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -15,6 +15,7 @@ import (
 type SlackHandler struct {
 	Spotify     spotify.Spotify
 	SlackWriter MessageWriter
+	channelID   string
 	skipVoted   bool
 	skipVotes   int
 	keepVotes   int
@@ -35,6 +36,7 @@ func NewSlackHandler(spotify spotify.Spotify, token, channelID string) http.Hand
 	handler := &SlackHandler{
 		Spotify:     spotify,
 		SlackWriter: NewPoster(token, channelID),
+		channelID:   channelID,
 	}
 	go handler.SlackWriter.StartPoster()
 	return handler
@@ -49,6 +51,9 @@ func (handler *SlackHandler) ServeHTTP(resp http.ResponseWriter, req *http.Reque
 
 	if !s.ValidateToken(os.Getenv("SLACK_VERIFICATION_TOKEN")) {
 		resp.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+	if s.ChannelID != handler.channelID {
 		return
 	}
 	switch s.Command {

--- a/slack/slack_poster.go
+++ b/slack/slack_poster.go
@@ -1,0 +1,40 @@
+package slack
+
+import (
+	"fmt"
+
+	"github.com/slack-go/slack"
+)
+
+type MessageWriter interface {
+	StartPoster()
+	Write(message string)
+}
+type Poster struct {
+	messages  chan string
+	channelID string
+	api       *slack.Client
+}
+
+func NewPoster(token, channelID string) MessageWriter {
+	return &Poster{
+		messages:  make(chan string, 10),
+		channelID: channelID,
+		api:       slack.New(token),
+	}
+}
+func (p *Poster) Write(message string) {
+	p.messages <- message
+}
+
+func (p *Poster) StartPoster() {
+	for {
+		msg := <-p.messages
+		attachment := slack.Attachment{}
+
+		_, _, err := p.api.PostMessage(p.channelID, slack.MsgOptionText(msg, false), slack.MsgOptionAttachments(attachment))
+		if err != nil {
+			fmt.Printf("Failed posting msg: %s", err)
+		}
+	}
+}

--- a/spotify/spotify.go
+++ b/spotify/spotify.go
@@ -49,6 +49,12 @@ func (s *SpotifyClient) WhatsPlaying() Result {
 	}
 
 	artistNames := []string{}
+	if playing.Item == nil {
+		return Result{
+			ID:     "",
+			Prompt: "Nothing is playing",
+		}
+	}
 	for _, artist := range playing.Item.Artists {
 		artistNames = append(artistNames, artist.Name)
 	}


### PR DESCRIPTION
For `/spotify playing` the bot will now respond in `shoreditch-tunes`. It will only listen to messages posted in that channel